### PR TITLE
Quote type attribute string in filter element in Query.java

### DIFF
--- a/src/main/java/net/i2cat/netconf/rpc/Query.java
+++ b/src/main/java/net/i2cat/netconf/rpc/Query.java
@@ -201,7 +201,7 @@ public class Query extends RPCElement implements java.io.Serializable {
 			if (filter != null) {
 				xml += "<filter";
 				if (filterType != null)
-					xml += " type=" + filterType;
+					xml += " type=\"" + filterType + "\"";
 				xml += ">" + filter + "</filter>";
 			}
 


### PR DESCRIPTION
XML attributes should be quoted, so 
    <filter type=subtree>...</filter> 
should really be
    <filter type="subtree">...</filter> 

A lot of XML parsers won't choke on this, but at the default settings for the lxml python library does choke on it.
