### PR TITLE
Replace String+=String with StringBuffer inside tight network read loop.

### DIFF
--- a/src/main/java/net/i2cat/netconf/transport/SSHTransport.java
+++ b/src/main/java/net/i2cat/netconf/transport/SSHTransport.java
@@ -261,8 +261,10 @@ public class SSHTransport implements Transport, ConnectionMonitor {
 
 						do {
 							tmp = reader.readLine();
-							buffer.append(tmp);
-						} while (!tmp.endsWith(delimiter) && !closed);
+							if (tmp != null) {
+								buffer.append(tmp);
+							}
+						} while (tmp != null && !tmp.endsWith(delimiter) && !closed);
 
 						parser.parse(new InputSource(new StringReader(buffer.toString())));
 


### PR DESCRIPTION
From the commit message: _This results in much better performance. I see roughly 75sec vs 15min for a roughly 4MB rpc-reply from a real SRX device. Also CPU usage is much lower._

I do have related question. When I found this problem (spending 100% of one core for 15min to deal with 4MB response from a device).  I originally wanted to fix it by hooking up session.getStdout() directly to a sax InputSource, because I figured that project probably handled reading efficiently. I figured you all might have tried that already and so I went looking in git log and found commit a327e923 by Paul that says: "fix to damn stream bug." What's the bug? Why didn't this work? Could it have been the Tee with logfile (which the current code isn't doing?) Or does Sax parse over-consume past the delimiter or something? 
