### PR TITLE
Configuration messages with correct structure.

### DIFF
--- a/src/main/java/net/i2cat/netconf/rpc/ReplyFactory.java
+++ b/src/main/java/net/i2cat/netconf/rpc/ReplyFactory.java
@@ -40,7 +40,7 @@ public class ReplyFactory {
 		reply.setAttributes(attributes);
 
 		// configuration
-		reply.setContain("configuration");
+		reply.setContainName("data");
 		reply.setContain(configuration);
 
 		return reply;


### PR DESCRIPTION
Configuration messages with correct structure. <data> tag instead of <configuration>.
