### PR TITLE
Abort for message queue

### DIFF
--- a/src/main/java/net/i2cat/netconf/NetconfSession.java
+++ b/src/main/java/net/i2cat/netconf/NetconfSession.java
@@ -204,6 +204,8 @@ public class NetconfSession implements TransportListener, MessageQueueListener, 
 			}
 		} catch (UncheckedTimeoutException e) {
 			throw new TransportException("Timeout while waiting for reply to query.", e);
+		} catch (TransportException e) {
+			throw e;
 		} catch (Exception e) {
 			throw new TransportException("Error getting reply to query: " + e.getMessage(), e);
 		}

--- a/src/main/java/net/i2cat/netconf/messageQueue/MessageQueue.java
+++ b/src/main/java/net/i2cat/netconf/messageQueue/MessageQueue.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
+import net.i2cat.netconf.errors.TransportException;
+import net.i2cat.netconf.rpc.Abort;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -30,7 +32,8 @@ import net.i2cat.netconf.rpc.RPCElement;
 
 public class MessageQueue {
 
-	static Log							log	= LogFactory.getLog(MessageQueue.class);
+	public static final String ABORT_MESSAGE_ID = "__ABORT_MESSAGE_ID__";
+	static Log log = LogFactory.getLog(MessageQueue.class);
 	Vector<MessageQueueListener>		listeners;
 	LinkedHashMap<String, RPCElement>	queue;
 
@@ -133,8 +136,14 @@ public class MessageQueue {
 		Callable<RPCElement> consumeCaller = new Callable<RPCElement>() {
 			public RPCElement call() throws Exception {
 				RPCElement element;
+				RPCElement abortElement;
 				synchronized (queue) {
 					while ((element = consumeById(messageIdFinal)) == null) {
+						if ((abortElement = consumeById(ABORT_MESSAGE_ID)) != null) {
+							Abort abort = (Abort)abortElement;
+							throw new TransportException("ABORTING: blockingConsumeById(" + messageIdFinal + "): "
+								        		 + abort.getMessage(), abort.getException());
+						}
 						try {
 							log.debug("Waiting (" + messageIdFinal + ")...");
 							queue.wait();
@@ -157,7 +166,7 @@ public class MessageQueue {
 			return timeLimiter.callWithTimeout(consumeCaller, timeout, TimeUnit.MILLISECONDS, true);
 		} catch (UncheckedTimeoutException e) {
 			log.debug("BlockingConsumeById(messageId=" + messageId + ") failed due to timeout.", e);
-			throw e;
+			throw new UncheckedTimeoutException(); 
 		} catch (Exception e) {
 			log.debug("BlockingConsumeById(messageId=" + messageId + ") failed.", e);
 			throw e;

--- a/src/main/java/net/i2cat/netconf/rpc/Abort.java
+++ b/src/main/java/net/i2cat/netconf/rpc/Abort.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Netconf4j.
+ *
+ * Netconf4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Netconf4j is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Netconf4j. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.i2cat.netconf.rpc;
+
+import net.i2cat.netconf.messageQueue.MessageQueue;
+
+/**
+ * An RPCElement to insert into the MessageQueue and trigger an abort.
+ */
+public class Abort extends RPCElement {
+	private String message;
+	private Exception exception;
+
+	public Abort(String message, Exception exception){
+		this.message = message;
+		this.exception = exception;
+		this.messageId = MessageQueue.ABORT_MESSAGE_ID;
+	}
+
+	public Abort(String message) {
+		this(message, null);
+	}
+
+	public Abort(Exception exception) {
+		this("Abort", exception);
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public Exception getException() {
+		return exception;
+	}
+
+	public void setException(Exception exception) {
+		this.exception = exception;
+	}
+}


### PR DESCRIPTION
At NetCitadel, we needed a way to have our Transport-derived class (Jsch Transport) abort when the underlying ssh library threw an exception of some sort. I think it's a reasonable addition to the upstream.
