### PR TITLE
Parse any arbitrary Reply and store information in 'contain'.

### DIFF
--- a/src/test/resources/netconf-messages/netconf-lldp-neighbors-information-reply.xml
+++ b/src/test/resources/netconf-messages/netconf-lldp-neighbors-information-reply.xml
@@ -1,0 +1,13 @@
+<rpc-reply message-id="101" xmlns:junos="http://xml.juniper.net/junos/13.2R2/junos">
+	<lldp-neighbors-information junos:style="brief">
+		<lldp-neighbor-information>
+			<lldp-local-port-id>ge-0/0/1</lldp-local-port-id>
+			<lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+			<lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+			<lldp-remote-chassis-id>84:18:88:14:cf:c0</lldp-remote-chassis-id>
+			<lldp-remote-port-id-subtype>Locally assigned</lldp-remote-port-id-subtype>
+			<lldp-remote-port-id>528</lldp-remote-port-id>
+			<lldp-remote-system-name>RootMXre0</lldp-remote-system-name>
+		</lldp-neighbor-information>
+	</lldp-neighbors-information>
+</rpc-reply>


### PR DESCRIPTION
With this improvement, any arbitrary Reply received by parser would store internal data in `contain` attribute and root element name in `containName` one.

As diff between original `TransportContentParser.java` and new one is not very well printed by GitHub, I generated this better [view](http://www.diffnow.com/?report=eyv4u).

Fixes [OPENNAAS-1437](http://jira.i2cat.net/browse/OPENNAAS-1437).
